### PR TITLE
Add document and job indexes

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -35,6 +35,16 @@
   weight = 10
 
 [[main]]
+  name = "Documents"
+  url = "/documents/"
+  weight = 20
+
+[[main]]
+  name = "Jobs"
+  url = "/jobs/"
+  weight = 25
+
+[[main]]
   name = "Blog"
   url = "/blog/"
   weight = 30

--- a/content/_index.md
+++ b/content/_index.md
@@ -18,9 +18,11 @@ Welcome to the official 1516 FAQ and Documentation Hub. We're here to help you f
 
 You can browse our different sections to find what you're looking for:
 
-*   **[Frequently Asked Questions (FAQs)](/faqs/)**: Get answers to common queries.
-*   **[Informational Pages](/pages/)**: Find detailed guides and standalone information.
-    *   Check out our example: [Dummy Test Page](/pages/dummy-test-page/)
-*   **[Latest Posts & Updates](/posts/)**: Stay informed with our recent articles.
+- **[Frequently Asked Questions (FAQs)](/faqs/)**: Get answers to common queries.
+- **[Informational Pages](/pages/)**: Find detailed guides and standalone information.
+  - Check out our example: [Dummy Test Page](/pages/dummy-test-page/)
+- **[Document Guides](/documents/)**: Step-by-step instructions for obtaining common certificates.
+- **[Job Listings](/jobs/)**: Explore opportunities based on your qualification.
+- **[Latest Posts & Updates](/posts/)**: Stay informed with our recent articles.
 
 We are continuously updating our content. If you can't find what you're looking for, please feel free to reach out.

--- a/content/documents/_index.md
+++ b/content/documents/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Document Guides"
+description: "Step-by-step guides for common documents"
+date: 2025-06-05T00:00:00+00:00
+lastmod: 2025-06-05T00:00:00+00:00
+draft: false
+weight: 80
+seo:
+  title: "Document Guides"
+  description: "Browse guides to apply for important documents"
+  noindex: false
+---
+
+Find instructions for obtaining common government documents.

--- a/content/documents/birth-certificate/municipal-corporation/andhra-pradesh/guntur-apply.md
+++ b/content/documents/birth-certificate/municipal-corporation/andhra-pradesh/guntur-apply.md
@@ -1,0 +1,40 @@
+---
+title: "Birth Certificate in Guntur"
+description: "Apply for a birth certificate in Guntur Municipal Corporation"
+document_type: "birth-certificate"
+issuer: "municipal-corporation"
+context: "andhra-pradesh"
+qualifications:
+  - "10th"
+state: "andhra-pradesh"
+fee: "₹30"
+validity: "Lifetime"
+processing_time: "8 working days"
+required_documents:
+  - "Hospital Birth Slip"
+  - "Parents' ID Proof"
+steps:
+  - "Step 1: Fill application at municipal office"
+  - "Step 2: Attach hospital slip and ID proofs"
+  - "Step 3: Collect certificate on due date"
+online_portal: "https://gunturcorporation.ap.gov.in"
+online_portal_instructions: "Use e-services for birth certificate"
+offices:
+  - name: "Guntur Municipal Corporation"
+    address: "Guntur, AP"
+    contact: "0863-5555 555"
+    hours: "10 AM - 4 PM"
+    map_link: "https://maps.example.com/gmc"
+faqs:
+  - question: "Can someone else collect it?"
+    answer: "Yes, with an authorization letter."
+notes: |
+  - Keep the acknowledgment safe till collection
+keywords: ["birth certificate", "guntur"]
+weight: 1000
+draft: false
+---
+
+# Birth Certificate in Guntur
+
+Submit the application along with the hospital slip at the municipal office.

--- a/content/documents/birth-certificate/municipal-corporation/telangana/hyderabad-application.md
+++ b/content/documents/birth-certificate/municipal-corporation/telangana/hyderabad-application.md
@@ -1,0 +1,40 @@
+---
+title: "Birth Certificate Application in Hyderabad"
+description: "Steps to apply for a birth certificate from the Hyderabad municipal corporation"
+document_type: "birth-certificate"
+issuer: "municipal-corporation"
+context: "telangana"
+qualifications:
+  - "10th"
+state: "telangana"
+fee: "₹30"
+validity: "Lifetime"
+processing_time: "7 working days"
+required_documents:
+  - "Hospital Birth Record"
+  - "Parents' Aadhaar Cards"
+steps:
+  - "Step 1: Visit the municipal website"
+  - "Step 2: Fill out the online form"
+  - "Step 3: Pay the fee and download the certificate"
+online_portal: "https://www.ghmc.gov.in"
+online_portal_instructions: "Navigate to Birth Certificate section"
+offices:
+  - name: "GHMC Office"
+    address: "Tank Bund Road, Hyderabad"
+    contact: "040-2111 1111"
+    hours: "10 AM - 4 PM"
+    map_link: "https://maps.example.com/ghmc"
+faqs:
+  - question: "Can I apply offline?"
+    answer: "Yes, you can visit your nearest GHMC circle office."
+notes: |
+  - Keep the hospital record ready for verification
+keywords: ["birth certificate", "hyderabad"]
+weight: 1000
+draft: false
+---
+
+# Birth Certificate Application in Hyderabad
+
+This guide explains how to request a birth certificate from the municipal corporation.

--- a/content/documents/caste-certificate/revenue-department/andhra-pradesh/sc-caste-certificate.md
+++ b/content/documents/caste-certificate/revenue-department/andhra-pradesh/sc-caste-certificate.md
@@ -1,0 +1,43 @@
+---
+title: "SC Caste Certificate Application in Andhra Pradesh"
+description: "Guide to obtaining an SC Caste Certificate through the Revenue Department in Andhra Pradesh"
+document_type: "caste-certificate"
+issuer: "revenue-department"
+context: "andhra-pradesh"
+qualifications:
+  - "10th"
+  - "12th"
+  - "bachelors"
+state: "andhra-pradesh"
+fee: "₹50"
+validity: "Lifetime"
+processing_time: "15 working days"
+required_documents:
+  - "Aadhaar Card"
+  - "Ration Card"
+  - "SSC Certificate"
+steps:
+  - "Step 1: Download the application form from the official website"
+  - "Step 2: Fill in the form and attach required documents"
+  - "Step 3: Submit at the Mandal Revenue Office"
+online_portal: "https://ap.meeseva.gov.in"
+online_portal_instructions: "Register and apply under Revenue Department"
+offices:
+  - name: "Mandal Revenue Office"
+    address: "Collectorate, Guntur, AP"
+    contact: "0863-2234000"
+    hours: "10 AM - 5 PM"
+    map_link: "https://maps.example.com/mro-guntur"
+faqs:
+  - question: "How long is the certificate valid?"
+    answer: "It is valid for life unless any detail changes."
+notes: |
+  - Processing times may vary based on workload
+keywords: ["caste certificate", "andhra pradesh"]
+weight: 1000
+draft: false
+---
+
+# SC Caste Certificate Application in Andhra Pradesh
+
+Follow the steps above to obtain your caste certificate from the Revenue Department.

--- a/content/documents/death-certificate/municipal-corporation/telangana/online-procedure.md
+++ b/content/documents/death-certificate/municipal-corporation/telangana/online-procedure.md
@@ -1,0 +1,40 @@
+---
+title: "Death Certificate Online Procedure in Telangana"
+description: "How to obtain a death certificate online via the municipal corporation"
+document_type: "death-certificate"
+issuer: "municipal-corporation"
+context: "telangana"
+qualifications:
+  - "12th"
+state: "telangana"
+fee: "₹40"
+validity: "Permanent"
+processing_time: "5 working days"
+required_documents:
+  - "Hospital Death Record"
+  - "Aadhaar of deceased"
+steps:
+  - "Step 1: Visit the municipal portal"
+  - "Step 2: Upload death record and personal details"
+  - "Step 3: Pay fee and download certificate"
+online_portal: "https://cdma.telangana.gov.in"
+online_portal_instructions: "Select death certificate services"
+offices:
+  - name: "Municipal Office"
+    address: "Somajiguda, Hyderabad"
+    contact: "040-2222 2222"
+    hours: "10 AM - 4 PM"
+    map_link: "https://maps.example.com/municipal"
+faqs:
+  - question: "Is physical presence required?"
+    answer: "No, the entire process can be completed online."
+notes: |
+  - Ensure details match the hospital record
+keywords: ["death certificate", "telangana"]
+weight: 1000
+draft: false
+---
+
+# Death Certificate Online Procedure in Telangana
+
+Follow these steps for an easy online application.

--- a/content/documents/domicile-certificate/revenue-department/andhra-pradesh/how-to-apply.md
+++ b/content/documents/domicile-certificate/revenue-department/andhra-pradesh/how-to-apply.md
@@ -1,0 +1,41 @@
+---
+title: "How to Apply for Domicile Certificate in Andhra Pradesh"
+description: "Procedure for domicile certificate through Revenue Department"
+document_type: "domicile-certificate"
+issuer: "revenue-department"
+context: "andhra-pradesh"
+qualifications:
+  - "10th"
+  - "12th"
+state: "andhra-pradesh"
+fee: "₹45"
+validity: "5 years"
+processing_time: "10 working days"
+required_documents:
+  - "Aadhaar Card"
+  - "Residence Proof"
+steps:
+  - "Step 1: Fill out application online"
+  - "Step 2: Upload residence proof"
+  - "Step 3: Submit and track status"
+online_portal: "https://ap.meeseva.gov.in"
+online_portal_instructions: "Login and select domicile certificate service"
+offices:
+  - name: "Revenue Office"
+    address: "Vijayawada, AP"
+    contact: "0866-2424 242"
+    hours: "10 AM - 5 PM"
+    map_link: "https://maps.example.com/revenue"
+faqs:
+  - question: "Is offline application available?"
+    answer: "Yes, you may apply at the nearest MeeSeva center."
+notes: |
+  - Carry originals for verification at collection time
+keywords: ["domicile certificate", "andhra pradesh"]
+weight: 1000
+draft: false
+---
+
+# How to Apply for Domicile Certificate in Andhra Pradesh
+
+Domicile certificate verifies your residence in the state.

--- a/content/documents/driving-license/transport-department/andhra-pradesh/learner-license.md
+++ b/content/documents/driving-license/transport-department/andhra-pradesh/learner-license.md
@@ -1,0 +1,41 @@
+---
+title: "Learner's Licence Application in Andhra Pradesh"
+description: "Guide to obtain a learner's licence via Transport Department"
+document_type: "driving-license"
+issuer: "transport-department"
+context: "andhra-pradesh"
+qualifications:
+  - "10th"
+  - "12th"
+state: "andhra-pradesh"
+fee: "₹150"
+validity: "6 months"
+processing_time: "Same day"
+required_documents:
+  - "Age Proof"
+  - "Address Proof"
+steps:
+  - "Step 1: Apply online on transport portal"
+  - "Step 2: Schedule slot for learner test"
+  - "Step 3: Attend test and receive licence"
+online_portal: "https://aptransport.org"
+online_portal_instructions: "Select Learner Licence service"
+offices:
+  - name: "RTA Office"
+    address: "Visakhapatnam"
+    contact: "0891-4444 444"
+    hours: "9 AM - 5 PM"
+    map_link: "https://maps.example.com/rta"
+faqs:
+  - question: "Is the test mandatory?"
+    answer: "Yes, you must pass the learner test."
+notes: |
+  - Reach 15 minutes before the scheduled slot
+keywords: ["learner licence", "andhra pradesh"]
+weight: 1000
+draft: false
+---
+
+# Learner's Licence Application in Andhra Pradesh
+
+Apply online and pass the learner's test to get your licence.

--- a/content/documents/gst-registration/gst-department/india/online-application.md
+++ b/content/documents/gst-registration/gst-department/india/online-application.md
@@ -1,0 +1,40 @@
+---
+title: "GST Registration Online Application"
+description: "Procedure for businesses to register under GST"
+document_type: "gst-registration"
+issuer: "gst-department"
+context: "india"
+qualifications:
+  - "bachelors"
+state: ""
+fee: "Free"
+validity: "Until cancelled"
+processing_time: "3 working days"
+required_documents:
+  - "PAN Card"
+  - "Address Proof"
+steps:
+  - "Step 1: Visit GST portal and create account"
+  - "Step 2: Fill form GST REG-01"
+  - "Step 3: Upload documents and submit"
+online_portal: "https://www.gst.gov.in"
+online_portal_instructions: "Register as a new taxpayer"
+offices:
+  - name: "GST Help Center"
+    address: "Every major city"
+    contact: "1800-1200-232"
+    hours: "9 AM - 6 PM"
+    map_link: "https://maps.example.com/gst"
+faqs:
+  - question: "Is there any fee?"
+    answer: "No, registration is free of cost."
+notes: |
+  - Save your ARN for tracking the application
+keywords: ["gst registration", "india"]
+weight: 1000
+draft: false
+---
+
+# GST Registration Online Application
+
+Register online through the GST portal using form GST REG-01.

--- a/content/documents/land-records/revenue-department/telangana/patta-transfer.md
+++ b/content/documents/land-records/revenue-department/telangana/patta-transfer.md
@@ -1,0 +1,40 @@
+---
+title: "Patta Transfer Procedure in Telangana"
+description: "Steps for transferring land records (Patta)"
+document_type: "land-records"
+issuer: "revenue-department"
+context: "telangana"
+qualifications:
+  - "bachelors"
+state: "telangana"
+fee: "₹500"
+validity: "Permanent"
+processing_time: "20 working days"
+required_documents:
+  - "Sale Deed"
+  - "Latest Tax Receipt"
+steps:
+  - "Step 1: Submit application at MeeSeva"
+  - "Step 2: Verification by Tahsildar"
+  - "Step 3: Collect updated pattadar passbook"
+online_portal: "https://ccla.telangana.gov.in"
+online_portal_instructions: "Select land services -> patta transfer"
+offices:
+  - name: "Tahsildar Office"
+    address: "Warangal"
+    contact: "0870-6666 666"
+    hours: "10 AM - 5 PM"
+    map_link: "https://maps.example.com/tahsildar"
+faqs:
+  - question: "Are mutations automatic?"
+    answer: "No, you must apply for patta transfer separately."
+notes: |
+  - Keep original sale deed for verification
+keywords: ["patta transfer", "telangana"]
+weight: 1000
+draft: false
+---
+
+# Patta Transfer Procedure in Telangana
+
+Apply through MeeSeva and follow up at the Tahsildar office.

--- a/content/documents/marriage-certificate/registration-department/telangana/step-by-step.md
+++ b/content/documents/marriage-certificate/registration-department/telangana/step-by-step.md
@@ -1,0 +1,40 @@
+---
+title: "Marriage Certificate Process in Telangana"
+description: "Step-by-step registration of marriage at Telangana"
+document_type: "marriage-certificate"
+issuer: "registration-department"
+context: "telangana"
+qualifications:
+  - "bachelors"
+state: "telangana"
+fee: "₹200"
+validity: "Permanent"
+processing_time: "3 working days"
+required_documents:
+  - "Aadhaar Cards of bride and groom"
+  - "Wedding Invitation Card"
+steps:
+  - "Step 1: Schedule appointment online"
+  - "Step 2: Attend registrar office with witnesses"
+  - "Step 3: Collect certificate"
+online_portal: "https://registration.telangana.gov.in"
+online_portal_instructions: "Use the slot booking for marriage registration"
+offices:
+  - name: "Registrar Office"
+    address: "Secunderabad"
+    contact: "040-5555 5555"
+    hours: "10 AM - 5 PM"
+    map_link: "https://maps.example.com/registrar"
+faqs:
+  - question: "Can NRIs apply?"
+    answer: "Yes, with valid passports and visas."
+notes: |
+  - Witnesses must carry ID proof
+keywords: ["marriage certificate", "telangana"]
+weight: 1000
+draft: false
+---
+
+# Marriage Certificate Process in Telangana
+
+Book your slot online and visit the registrar office.

--- a/content/documents/pan-card/income-tax-department/india/apply-new-pan.md
+++ b/content/documents/pan-card/income-tax-department/india/apply-new-pan.md
@@ -1,0 +1,40 @@
+---
+title: "Apply for a New PAN Card"
+description: "Steps to get a new Permanent Account Number online"
+document_type: "pan-card"
+issuer: "income-tax-department"
+context: "india"
+qualifications:
+  - "12th"
+state: ""
+fee: "₹93"
+validity: "Lifetime"
+processing_time: "15 working days"
+required_documents:
+  - "Identity Proof"
+  - "Address Proof"
+steps:
+  - "Step 1: Visit NSDL PAN website"
+  - "Step 2: Fill Form 49A"
+  - "Step 3: Submit documents and payment"
+online_portal: "https://www.onlineservices.nsdl.com"
+online_portal_instructions: "Select new PAN for Indian citizens"
+offices:
+  - name: "PAN Center"
+    address: "Across India"
+    contact: "020-2721 8080"
+    hours: "9 AM - 6 PM"
+    map_link: "https://maps.example.com/pan"
+faqs:
+  - question: "Is e-PAN issued?"
+    answer: "Yes, an e-PAN will be emailed after approval."
+notes: |
+  - Keep scanned copies within size limits
+keywords: ["pan card", "india"]
+weight: 1000
+draft: false
+---
+
+# Apply for a New PAN Card
+
+Complete Form 49A on the NSDL website to get a PAN card.

--- a/content/documents/passport/passport-office/india/apply-online.md
+++ b/content/documents/passport/passport-office/india/apply-online.md
@@ -1,0 +1,42 @@
+---
+title: "How to Apply for an Indian Passport Online"
+description: "Instructions for online passport application via Passport Seva"
+document_type: "passport"
+issuer: "passport-office"
+context: "india"
+qualifications:
+  - "10th"
+  - "12th"
+  - "bachelors"
+state: ""
+fee: "₹1500"
+validity: "10 years"
+processing_time: "30 working days"
+required_documents:
+  - "Aadhaar Card"
+  - "Address Proof"
+steps:
+  - "Step 1: Register on Passport Seva portal"
+  - "Step 2: Fill application form and pay fee"
+  - "Step 3: Book appointment and visit PSK"
+online_portal: "https://passportindia.gov.in"
+online_portal_instructions: "Create account and choose fresh passport service"
+offices:
+  - name: "Passport Seva Kendra"
+    address: "Begumpet, Hyderabad"
+    contact: "040-2770 0700"
+    hours: "9 AM - 4 PM"
+    map_link: "https://maps.example.com/psk"
+faqs:
+  - question: "Is police verification required?"
+    answer: "Yes, in most cases."
+notes: |
+  - Carry original documents for appointment
+keywords: ["passport application", "india"]
+weight: 1000
+draft: false
+---
+
+# How to Apply for an Indian Passport Online
+
+The Passport Seva portal simplifies the application process.

--- a/content/documents/ration-card/civil-supplies/andhra-pradesh/new-ration-card.md
+++ b/content/documents/ration-card/civil-supplies/andhra-pradesh/new-ration-card.md
@@ -1,0 +1,40 @@
+---
+title: "Apply for a New Ration Card in Andhra Pradesh"
+description: "Instructions to obtain a new ration card via Civil Supplies"
+document_type: "ration-card"
+issuer: "civil-supplies"
+context: "andhra-pradesh"
+qualifications:
+  - "10th"
+state: "andhra-pradesh"
+fee: "₹20"
+validity: "5 years"
+processing_time: "14 working days"
+required_documents:
+  - "Aadhaar Cards of family"
+  - "Income Proof"
+steps:
+  - "Step 1: Submit online application"
+  - "Step 2: Verification by department"
+  - "Step 3: Collect card from ration shop"
+online_portal: "https://epds.ap.gov.in"
+online_portal_instructions: "Use the new ration card service"
+offices:
+  - name: "Civil Supplies Office"
+    address: "Vijayawada"
+    contact: "0866-3333 333"
+    hours: "10 AM - 4 PM"
+    map_link: "https://maps.example.com/cs"
+faqs:
+  - question: "Can I update members later?"
+    answer: "Yes, through the same portal."
+notes: |
+  - Ensure Aadhaar details match
+keywords: ["ration card", "andhra pradesh"]
+weight: 1000
+draft: false
+---
+
+# Apply for a New Ration Card in Andhra Pradesh
+
+Complete the online application and track status on the portal.

--- a/content/documents/vehicle-registration/transport-department/telangana/new-vehicle-reg.md
+++ b/content/documents/vehicle-registration/transport-department/telangana/new-vehicle-reg.md
@@ -1,0 +1,40 @@
+---
+title: "New Vehicle Registration in Telangana"
+description: "Guide to register a new vehicle with the Transport Department"
+document_type: "vehicle-registration"
+issuer: "transport-department"
+context: "telangana"
+qualifications:
+  - "bachelors"
+state: "telangana"
+fee: "Varies"
+validity: "15 years"
+processing_time: "2 working days"
+required_documents:
+  - "Sales Invoice"
+  - "Insurance Certificate"
+steps:
+  - "Step 1: Submit Form 20 at RTA office"
+  - "Step 2: Pay road tax and fees"
+  - "Step 3: Receive RC"
+online_portal: "https://transport.telangana.gov.in"
+online_portal_instructions: "Book a slot for new vehicle registration"
+offices:
+  - name: "RTA Office"
+    address: "Khairatabad, Hyderabad"
+    contact: "040-7777 7777"
+    hours: "10 AM - 5 PM"
+    map_link: "https://maps.example.com/rta-tg"
+faqs:
+  - question: "Is temporary registration allowed?"
+    answer: "Yes, dealers usually provide temporary registration."
+notes: |
+  - Carry original invoices during inspection
+keywords: ["vehicle registration", "telangana"]
+weight: 1000
+draft: false
+---
+
+# New Vehicle Registration in Telangana
+
+Submit Form 20 and pay the required fees at the RTA office.

--- a/content/documents/voter-id/election-commission/telangana/new-registration.md
+++ b/content/documents/voter-id/election-commission/telangana/new-registration.md
@@ -1,0 +1,40 @@
+---
+title: "Voter ID New Registration in Telangana"
+description: "Step-by-step voter ID application through Election Commission"
+document_type: "voter-id"
+issuer: "election-commission"
+context: "telangana"
+qualifications:
+  - "12th"
+state: "telangana"
+fee: "Free"
+validity: "As long as details remain same"
+processing_time: "21 working days"
+required_documents:
+  - "Proof of Age"
+  - "Proof of Residence"
+steps:
+  - "Step 1: Visit NVSP portal"
+  - "Step 2: Fill Form 6 online"
+  - "Step 3: Track status"
+online_portal: "https://voterportal.eci.gov.in"
+online_portal_instructions: "Register and select Form 6"
+offices:
+  - name: "Election Office"
+    address: "Nampally, Hyderabad"
+    contact: "040-2323 2323"
+    hours: "10 AM - 5 PM"
+    map_link: "https://maps.example.com/eci"
+faqs:
+  - question: "Is offline registration available?"
+    answer: "Yes, you can submit Form 6 at the ERO office."
+notes: |
+  - Keep scanned copies ready for uploading
+keywords: ["voter id", "telangana"]
+weight: 1000
+draft: false
+---
+
+# Voter ID New Registration in Telangana
+
+Citizens can register as voters by submitting Form 6 online.

--- a/content/jobs/_index.md
+++ b/content/jobs/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Job Listings"
+description: "Opportunities categorized by qualification and sector"
+date: 2025-06-05T00:00:00+00:00
+lastmod: 2025-06-05T00:00:00+00:00
+draft: false
+weight: 90
+seo:
+  title: "Job Listings"
+  description: "Browse the latest job openings"
+  noindex: false
+---
+
+Explore job opportunities suited to your education level and interests.

--- a/content/jobs/government/12th/clerk-typist.md
+++ b/content/jobs/government/12th/clerk-typist.md
@@ -1,0 +1,41 @@
+---
+title: "Clerk Typist Recruitment"
+description: "Government clerical position for 12th pass candidates"
+sector: "government"
+min_qualification: "12th"
+state: "telangana"
+salary: "₹20,000 - ₹25,000 per month"
+job_type: "Permanent"
+location: "District Collectorates"
+experience: "Freshers can apply"
+last_date: "2025-08-15"
+application_fee: "₹200"
+selection_process:
+  - "Written Test"
+  - "Typing Test"
+  - "Document Verification"
+eligibility:
+  - "Must have passed Intermediate"
+  - "Age 18-44 years"
+  - "Knowledge of typing in English/Telugu"
+how_to_apply: |
+  Apply online through the official district portal.
+application_link: "https://districts.telangana.gov.in"
+important_dates:
+  - event: "Application Start"
+    date: "2025-07-01"
+  - event: "Last Date"
+    date: "2025-08-15"
+faqs:
+  - question: "Is computer certificate required?"
+    answer: "Yes, basic computer knowledge certificate is needed."
+notes: |
+  - Read the official notification carefully before applying
+keywords: ["clerk typist", "government job"]
+weight: 1000
+draft: false
+---
+
+# Clerk Typist Recruitment
+
+Government offices require clerks for typing and filing work.

--- a/content/jobs/government/bachelors/firefighter.md
+++ b/content/jobs/government/bachelors/firefighter.md
@@ -1,0 +1,39 @@
+---
+title: "Firefighter"
+description: "Government recruitment for firefighters"
+sector: "government"
+min_qualification: "bachelors"
+state: "andhra-pradesh"
+salary: "₹28,000 per month"
+job_type: "Permanent"
+location: "Various districts"
+experience: "Freshers"
+last_date: "2025-08-31"
+application_fee: "₹150"
+selection_process:
+  - "Physical Test"
+  - "Written Test"
+  - "Interview"
+eligibility:
+  - "Degree in any discipline"
+  - "Physically fit"
+how_to_apply: "Apply through AP Fire Services website"
+application_link: "https://fireservices.ap.gov.in"
+important_dates:
+  - event: "Application Start"
+    date: "2025-07-01"
+  - event: "Last Date"
+    date: "2025-08-31"
+faqs:
+  - question: "Is swimming mandatory?"
+    answer: "Yes, candidates should know swimming."
+notes: |
+  - Prepare for physical endurance tests
+keywords: ["firefighter", "AP fire services"]
+weight: 1000
+draft: false
+---
+
+# Firefighter
+
+AP Fire Services invites applications for firefighter posts.

--- a/content/jobs/government/bachelors/state-tax-officer.md
+++ b/content/jobs/government/bachelors/state-tax-officer.md
@@ -1,0 +1,41 @@
+---
+title: "State Tax Officer"
+description: "Recruitment for graduates as State Tax Officers"
+sector: "government"
+min_qualification: "bachelors"
+state: "telangana"
+salary: "₹45,000 - ₹80,000 per month"
+job_type: "Permanent"
+location: "Telangana"
+experience: "Freshers eligible"
+last_date: "2025-09-30"
+application_fee: "₹300"
+selection_process:
+  - "Preliminary Exam"
+  - "Mains Exam"
+  - "Interview"
+eligibility:
+  - "Bachelor's degree from a recognized university"
+  - "Age 21-30 years"
+  - "Knowledge of local language"
+how_to_apply: |
+  Apply through the state public service commission website.
+application_link: "https://tspsc.gov.in"
+important_dates:
+  - event: "Application Start"
+    date: "2025-08-01"
+  - event: "Last Date"
+    date: "2025-09-30"
+faqs:
+  - question: "Is there negative marking?"
+    answer: "Yes, 0.25 marks for each wrong answer."
+notes: |
+  - Keep scanned documents ready
+keywords: ["tax officer", "TSPSC"]
+weight: 1000
+draft: false
+---
+
+# State Tax Officer
+
+Graduates can join the state service as tax officers via TSPSC.

--- a/content/jobs/government/masters/civil-services-exam.md
+++ b/content/jobs/government/masters/civil-services-exam.md
@@ -1,0 +1,39 @@
+---
+title: "Civil Services Examination"
+description: "UPSC Civil Services exam notification"
+sector: "government"
+min_qualification: "masters"
+state: "india"
+salary: "As per rules"
+job_type: "Permanent"
+location: "Across India"
+experience: "Freshers"
+last_date: "2025-03-01"
+application_fee: "₹100"
+selection_process:
+  - "Preliminary Exam"
+  - "Mains Exam"
+  - "Interview"
+eligibility:
+  - "Graduate degree (master's preferred)"
+  - "Age 21-32 years"
+how_to_apply: "Apply online at UPSC website"
+application_link: "https://upsc.gov.in"
+important_dates:
+  - event: "Application Start"
+    date: "2024-12-10"
+  - event: "Last Date"
+    date: "2025-03-01"
+faqs:
+  - question: "How many attempts allowed?"
+    answer: "General category has 6 attempts."
+notes: |
+  - Read the official notification thoroughly
+keywords: ["UPSC", "civil services"]
+weight: 1000
+draft: false
+---
+
+# Civil Services Examination
+
+Prestigious exam to recruit for various central government services.

--- a/content/jobs/healthcare/bachelors/staff-nurse.md
+++ b/content/jobs/healthcare/bachelors/staff-nurse.md
@@ -1,0 +1,38 @@
+---
+title: "Staff Nurse"
+description: "Healthcare facility hiring qualified nurses"
+sector: "healthcare"
+min_qualification: "bachelors"
+state: "andhra-pradesh"
+salary: "₹30,000 per month"
+job_type: "Contract"
+location: "Visakhapatnam"
+experience: "1 year"
+last_date: "2025-07-31"
+application_fee: "₹100"
+selection_process:
+  - "Written Test"
+  - "Interview"
+eligibility:
+  - "B.Sc Nursing with registration"
+  - "Age below 35"
+how_to_apply: "Submit resume at hospital HR desk"
+application_link: "https://hospital.example.com/jobs"
+important_dates:
+  - event: "Application Start"
+    date: "2025-06-20"
+  - event: "Last Date"
+    date: "2025-07-31"
+faqs:
+  - question: "Is accommodation provided?"
+    answer: "Limited hostel facilities available."
+notes: |
+  - Night shifts may be required
+keywords: ["staff nurse", "hospital"]
+weight: 1000
+draft: false
+---
+
+# Staff Nurse
+
+Hospital in Visakhapatnam requires qualified nurses on contract basis.

--- a/content/jobs/private/10th/data-entry-operator.md
+++ b/content/jobs/private/10th/data-entry-operator.md
@@ -1,0 +1,39 @@
+---
+title: "Data Entry Operator"
+description: "Private sector opening for 10th pass candidates"
+sector: "private"
+min_qualification: "10th"
+state: "andhra-pradesh"
+salary: "₹12,000 - ₹15,000 per month"
+job_type: "Contract"
+location: "Vijayawada"
+experience: "0-1 year"
+last_date: "2025-07-20"
+application_fee: "No fee"
+selection_process:
+  - "Typing Test"
+  - "Interview"
+  - "Document Verification"
+eligibility:
+  - "10th pass with basic computer knowledge"
+  - "Typing speed 30 wpm"
+how_to_apply: "Send resume by email"
+application_link: "mailto:hr@example.com"
+important_dates:
+  - event: "Application Start"
+    date: "2025-06-10"
+  - event: "Last Date"
+    date: "2025-07-20"
+faqs:
+  - question: "Is prior experience required?"
+    answer: "Not mandatory but preferred."
+notes: |
+  - Walk-in interviews may be scheduled
+keywords: ["data entry", "private job"]
+weight: 1000
+draft: false
+---
+
+# Data Entry Operator
+
+Private company requires data entry operators in Vijayawada.

--- a/content/jobs/private/12th/customer-support-executive.md
+++ b/content/jobs/private/12th/customer-support-executive.md
@@ -1,0 +1,38 @@
+---
+title: "Customer Support Executive"
+description: "Call center job for 12th pass candidates"
+sector: "private"
+min_qualification: "12th"
+state: "telangana"
+salary: "₹18,000 per month"
+job_type: "Permanent"
+location: "Hyderabad"
+experience: "0-1 year"
+last_date: "2025-08-10"
+application_fee: "No fee"
+selection_process:
+  - "Telephonic Interview"
+  - "HR Interview"
+eligibility:
+  - "Good communication skills"
+  - "Basic computer knowledge"
+how_to_apply: "Submit online application"
+application_link: "https://jobs.example.com/cse"
+important_dates:
+  - event: "Application Start"
+    date: "2025-06-01"
+  - event: "Last Date"
+    date: "2025-08-10"
+faqs:
+  - question: "Is night shift compulsory?"
+    answer: "Rotational shifts are followed."
+notes: |
+  - Candidates should have a stable internet connection for online training
+keywords: ["customer support", "call center"]
+weight: 1000
+draft: false
+---
+
+# Customer Support Executive
+
+Handle inbound customer queries for a telecom provider.

--- a/content/jobs/private/bachelors/software-engineer.md
+++ b/content/jobs/private/bachelors/software-engineer.md
@@ -1,0 +1,39 @@
+---
+title: "Software Engineer"
+description: "Entry-level software engineer position"
+sector: "private"
+min_qualification: "bachelors"
+state: "telangana"
+salary: "₹4 - ₹6 LPA"
+job_type: "Permanent"
+location: "Hyderabad"
+experience: "0-2 years"
+last_date: "2025-10-01"
+application_fee: "No fee"
+selection_process:
+  - "Online Test"
+  - "Technical Interview"
+  - "HR Interview"
+eligibility:
+  - "B.Tech/BE in Computer Science or related field"
+  - "Good programming skills"
+how_to_apply: "Apply via company careers page"
+application_link: "https://company.example.com/careers"
+important_dates:
+  - event: "Application Start"
+    date: "2025-06-15"
+  - event: "Last Date"
+    date: "2025-10-01"
+faqs:
+  - question: "Is remote work available?"
+    answer: "Yes, hybrid options exist."
+notes: |
+  - Prepare for coding tests
+keywords: ["software engineer", "IT jobs"]
+weight: 1000
+draft: false
+---
+
+# Software Engineer
+
+Join the development team working on web applications.

--- a/content/jobs/private/diploma/electrical-technician.md
+++ b/content/jobs/private/diploma/electrical-technician.md
@@ -1,0 +1,38 @@
+---
+title: "Electrical Technician"
+description: "Private firm hiring diploma holders in electrical engineering"
+sector: "private"
+min_qualification: "diploma"
+state: "telangana"
+salary: "₹20,000 - ₹25,000 per month"
+job_type: "Permanent"
+location: "Hyderabad"
+experience: "2 years"
+last_date: "2025-09-15"
+application_fee: "No fee"
+selection_process:
+  - "Technical Test"
+  - "Interview"
+eligibility:
+  - "Diploma in Electrical Engineering"
+  - "Ability to read electrical diagrams"
+how_to_apply: "Email your CV"
+application_link: "mailto:jobs@powerexample.com"
+important_dates:
+  - event: "Application Start"
+    date: "2025-07-01"
+  - event: "Last Date"
+    date: "2025-09-15"
+faqs:
+  - question: "Is accommodation provided?"
+    answer: "No, candidates must arrange their own."
+notes: |
+  - Field work may be required
+keywords: ["electrical technician", "diploma"]
+weight: 1000
+draft: false
+---
+
+# Electrical Technician
+
+Work on maintenance of electrical equipment at client sites.


### PR DESCRIPTION
## Summary
- create listing pages for documents and jobs
- link these sections from the home page
- update menu to show "Documents" and "Jobs"

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68405fa2413c8326abc1727bf4f36fd4